### PR TITLE
Update swiftlint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,9 @@
 disabled_rules:
   - nesting
+  - unused_closure_parameter
+  - closure_parameter_position
+  - empty_parentheses_with_trailing_closure
+  - redundant_string_enum_value
 opt_in_rules: # some rules are only opt-in
   - empty_count
   # Find all the available rules by running:
@@ -32,7 +36,7 @@ file_length:
 # naming rules can set warnings/errors for min_length and max_length
 # additionally they can set excluded names
 type_name:
-  min_length: 2 # only warning
+  min_length: 1 # only warning
   max_length: # warning and error
     warning: 40
     error: 50


### PR DESCRIPTION
Having a lot of warnings can confuse us, so it's great that we can have a common set of rules that we agree on

## unused_closure_parameter

This can cause issue like https://github.com/realm/SwiftLint/issues/1175 when the function is generic

## closure_parameter_position

This rule is good. However in cases similar to Cartography when the list of closure parameters is long, we tend to move them to a new line

```
constrain(percentageLabel, titleLabel) {
      (percentageLabel: LayoutProxy, titleLabel: LayoutProxy) in

      // ...
}
```

## empty_parentheses_with_trailing_closure

This rule is good. However in cases we have a constructor that accepts a closure, we tend to call it like `let person = Person() { ... }` instead of `let person = Person { ... }` which makes the intention more clear that we 're constructing an object

## redundant_string_enum_value

I have no strong opinion on this actually. It is redundant in a way, but more explicit in another way 🤔 

```
enum Deployment: String {
   case staging = "staging"
   case production = "production"
}
```

## min_length

This is good. But since it confuses `public typealias T = U` with variable name constraints, so I reduce it to 1 for now